### PR TITLE
1.1.1 update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dev": true
     },
     "gruetest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gruetest/-/gruetest-1.0.1.tgz",
-      "integrity": "sha512-Hmk4WTcOJs4w+pZTS8SHoykF+7ncJUIAD93/CWdrkgHiApbM10L2Vgc9gG7YH55NPKTRjaAM1Ex6hC1ivJmaEA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/gruetest/-/gruetest-1.0.2.tgz",
+      "integrity": "sha512-7jtL2aMd9mpfo4Dy45PvmFNQIgzUoyd+rmwfWkEhM1N8Zx4j81bNdYJIfNNpoE+INUlIUi3aBcvSJ6uMv228Zw==",
       "dev": true
     },
     "typescript": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dparse",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A dice notation parser and evaluator.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/RoleSave/dparse#readme",
   "devDependencies": {
     "@types/node": "^13.13.0",
-    "gruetest": "^1.0.1",
+    "gruetest": "^1.0.2",
     "typescript": "^3.8.3"
   }
 }

--- a/src/core/expressions.ts
+++ b/src/core/expressions.ts
@@ -1,3 +1,4 @@
+import { Op } from './operators'
 
 /// SECTION: Results
 
@@ -28,6 +29,8 @@ export type BaseResult = Result_base & { type: 'basic' }
 /** A result from a dice-based expression. */
 export type DiceResult = Result_base & {
   type: 'dice'
+  /** The expression evaluated to get this result. */
+  source: Op
   /** A list of individual roll numbers. */
   rolls: number[]
   /** The number of expected rolls. Not guaranteed to equal `rolls.length` (see exploding dice in particular). */
@@ -37,6 +40,9 @@ export type DiceResult = Result_base & {
   /** The minimum roll for a single die of the type used for this result. */
   minRoll?: number
 }
+
+export function isBaseResult(result: Result): result is BaseResult { return result.type === 'basic' }
+export function isDiceResult(result: Result): result is DiceResult { return result.type === 'dice' }
 
 /// SECTION: Core expression types
 
@@ -107,3 +113,4 @@ import '../opdefs/dice'
 import '../opdefs/dnd5e'
 import '../opdefs/keep'
 import '../opdefs/reroll'
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 
-export { Expr, Result, ExprCtx } from './core/expressions'
+export { Expr, Result, ExprCtx, isBaseResult, isDiceResult } from './core/expressions'
 export { Operators, Op, OpDef } from './core/operators'
 export { parseExpr, parseExprList } from './core/parse'

--- a/src/opdefs/dice.ts
+++ b/src/opdefs/dice.ts
@@ -12,7 +12,7 @@ const simpleDie = (l: Result, r: Result): Omit<DiceResult, 'source'> => {
     type: 'dice',
     rolls: rolls,
     value: rolls.reduce(sum, 0),
-    prev: [ ...l.prev, ...r.prev ],
+    prev: [ l, r ],
     rollCount: l.value,
     maxRoll: r.value
   }
@@ -41,7 +41,7 @@ Ops.registerOp({
       rolls: rolls,
       value: rolls.reduce(sum, 0),
       source: op,
-      prev: l.prev,
+      prev: [ l ],
       rollCount: l.value,
       maxRoll: 1,
       minRoll: -1
@@ -83,10 +83,14 @@ Ops.registerOp({
         ...result,
         rolls: allRolls,
         value: allRolls.reduce(sum, 0),
-        prev: [ explResult, ...result.prev ]
+        prev: [ explResult ]
       }
     }
   
-    return result
+    return {
+      ...result,
+      source: op,
+      prev: [ result ]
+    }
   }
 })

--- a/src/opdefs/dnd5e.ts
+++ b/src/opdefs/dnd5e.ts
@@ -14,7 +14,7 @@ Ops.registerOp({
     return {
       ...ordRoll[0],
       source: op,
-      prev: [ ordRoll[1], ...orgRoll.prev ]
+      prev: ordRoll
     }
   }
 })
@@ -30,7 +30,7 @@ Ops.registerOp({
     return {
       ...ordRoll[0],
       source: op,
-      prev: [ ordRoll[1], ...orgRoll.prev ]
+      prev: ordRoll
     }
   }
 })
@@ -64,7 +64,11 @@ Ops.registerOp({
   eval: (op, _l) => {
     let l = _l as DiceResult
     if(l.value > l.rolls.length * (typeof l.minRoll !== 'undefined' ? l.minRoll : 1))
-      return l
+      return {
+        ...l,
+        source: op,
+        prev: [ l ]
+      }
 
     let effect = randOf(wildMagicEffects),
         effectRolls: Result[] = []
@@ -78,6 +82,8 @@ Ops.registerOp({
 
     return {
       ...l,
+      source: op,
+      prev: [ l ],
       statuses: [
         ...l.statuses||[],
         { fromOp: op.def.name,


### PR DESCRIPTION
- Added `isBaseResult` and `isDiceResult`.
- Changed `Result#prev` to be more consistent across pre-packaged operators.
- Changed the type of `DiceResult#source` to specifically require an `Op`.
- Updated to gruetest v1.0.2 (see swordglowsblue/gruetest@019b598)